### PR TITLE
change docker stop signal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,5 @@ EXPOSE 8080
 
 ENTRYPOINT ["/root/.local/bin/jawanndenn", "--port", "8080", "--host", "0.0.0.0"]
 CMD ["--database-pickle", "/data/polls.pickle"]
+
+STOPSIGNAL SIGINT


### PR DESCRIPTION
Docker sends SIGTERM by default, which is not captured by the process. SIGINT (CTRL+C) is captured and gracefully ends the process and prevents data loss.