### PR TITLE
JS: Trim the voterName before checking its length

### DIFF
--- a/jawanndenn/static/js/poll.js
+++ b/jawanndenn/static/js/poll.js
@@ -164,7 +164,7 @@ var enableButton = function(selector, enabled) {
 };
 
 var syncSaveButton = function() {
-    var good = ($( '#voterName' ).val().length > 0);
+    var good = ($( '#voterName' ).val().trim().length > 0);
     var saveButton = $( '#submitVote' );
     enableButton(saveButton, good);
 };


### PR DESCRIPTION
Currently it's possible to submit a vote with a space as input for your name. By trimming the value of the input before checking its length, we can prevent this from happening.