### PR TITLE
use valid value for X-Frame-Options

### DIFF
--- a/jawanndenn/tests/test_views.py
+++ b/jawanndenn/tests/test_views.py
@@ -175,7 +175,7 @@ class ServeUsingFindersTest(TestCase):
 
         # Our app, asset used in <iframe>
         ('jawanndenn', '3rdparty/github-buttons-4.0.1/docs/github-btn.html',
-         'SAMESITE'),
+         'sameorigin'),
 
         # Arbitrary asset of arbitary other app
         ('django.contrib.admin', 'admin/css/responsive.css', 'DENY'),

--- a/jawanndenn/urls.py
+++ b/jawanndenn/urls.py
@@ -31,7 +31,7 @@ def _serve_with_headers_fixed(request, path, insecure=False, **kwargs):
     # Allow loading of github-btn.html in an <iframe>
     if (path.startswith('3rdparty/github-buttons-')
             and path.endswith('/docs/github-btn.html')):
-        response['X-Frame-Options'] = 'SAMESITE'
+        response['X-Frame-Options'] = 'sameorigin'
 
     return response
 


### PR DESCRIPTION
SAMESITE is not a valid value for the X-Frame-Options header.

This is also causing an error in the Firefox developer console:
```
Invalid X-Frame-Options: “SAMESITE” header from “https://jawanndenn.de/static/3rdparty/github-buttons-4.0.1/d…-btn.html?user=hartwork&repo=jawanndenn&type=star&count=true” loaded into “https://jawanndenn.de/”.
```

The intention was probably to set it to sameorigin, see:
https://developer.mozilla.org/de/docs/Web/HTTP/Headers/X-Frame-Options