### PR TITLE
settings: Fix CSRF settings for Django >=4

### DIFF
--- a/jawanndenn/settings.py
+++ b/jawanndenn/settings.py
@@ -39,6 +39,9 @@ _ALLOWED_HOSTS_DEFAULT = ','.join([
 ALLOWED_HOSTS = (
     os.environ.get('JAWANNDENN_ALLOWED_HOSTS') or _ALLOWED_HOSTS_DEFAULT
 ).split(',')
+CSRF_TRUSTED_ORIGINS = {f'{scheme}://{host}'
+                        for scheme in ('http', 'https')
+                        for host in ALLOWED_HOSTS}
 
 SECURE_REFERRER_POLICY = 'origin'
 


### PR DESCRIPTION
Symptom was that `POST`ing to /create would fail with message `Origin checking failed - https://jawanndenn.de does not match any trusted origins.`

Related docs:
https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins