### PR TITLE
`build_and_test_using_docker.yml`: Limit `requests<2.32.0` to fix docker-compose

### DIFF
--- a/.github/workflows/build_and_test_using_docker.yml
+++ b/.github/workflows/build_and_test_using_docker.yml
@@ -27,6 +27,7 @@ jobs:
             --no-warn-script-location \
             'docker<7' \
             'PyYAML==5.3.1' \
+            'requests<2.32.0' \
             'urllib3<2' \
             docker-compose
           echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Related:
- https://github.com/psf/requests/issues/6707#issuecomment-2122490651
- https://github.com/docker/docker-py/issues/3256
- https://github.com/docker/docker-py/pull/3257