### PR TITLE
settings: Pin `DEFAULT_AUTO_FIELD` to `django.db.models.AutoField` for now (fixes #1404)

### DIFF
--- a/jawanndenn/settings.py
+++ b/jawanndenn/settings.py
@@ -115,6 +115,8 @@ else:
         }
     }
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # Logging
 # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-LOGGING
 


### PR DESCRIPTION
Fixes #1404