### PR TITLE
frontend: Migrate from `^version` to `>=version`

### DIFF
--- a/jawanndenn/frontend/package.json
+++ b/jawanndenn/frontend/package.json
@@ -11,25 +11,25 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@mui/material": "^7.1.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "@emotion/react": ">=11.14.0",
+    "@emotion/styled": ">=11.14.0",
+    "@mui/material": ">=7.1.1",
+    "react": ">=19.1.0",
+    "react-dom": ">=19.1.0"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.7",
-    "@eslint/js": "^9.23.0",
-    "@rsbuild/core": "^1.3.15",
-    "@rsbuild/plugin-react": "^1.3.2",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.6",
-    "eslint": "^9.23.0",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "globals": "^16.0.0",
-    "prettier": "^3.5.3",
-    "typescript": "^5.8.3",
-    "typescript-eslint": "^8.29.0"
+    "@eslint/compat": ">=1.2.7",
+    "@eslint/js": ">=9.23.0",
+    "@rsbuild/core": ">=1.3.15",
+    "@rsbuild/plugin-react": ">=1.3.2",
+    "@types/react": ">=19.1.2",
+    "@types/react-dom": ">=19.1.6",
+    "eslint": ">=9.23.0",
+    "eslint-plugin-react": ">=7.37.4",
+    "eslint-plugin-react-hooks": ">=5.2.0",
+    "globals": ">=16.0.0",
+    "prettier": ">=3.5.3",
+    "typescript": ">=5.8.3",
+    "typescript-eslint": ">=8.29.0"
   }
 }


### PR DESCRIPTION
The plan is to unlimit updates by Dependabot and to manually re-add limits once things turn out incompatible.
