### PR TITLE
frontend: Get `package-lock.json` back in sync (follow-up to #1438)

### DIFF
--- a/jawanndenn/frontend/package-lock.json
+++ b/jawanndenn/frontend/package-lock.json
@@ -8,26 +8,26 @@
       "name": "frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.0",
-        "@mui/material": "^7.1.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "@emotion/react": ">=11.14.0",
+        "@emotion/styled": ">=11.14.0",
+        "@mui/material": ">=7.1.1",
+        "react": ">=19.1.0",
+        "react-dom": ">=19.1.0"
       },
       "devDependencies": {
-        "@eslint/compat": "^1.2.7",
-        "@eslint/js": "^9.23.0",
-        "@rsbuild/core": "^1.3.15",
-        "@rsbuild/plugin-react": "^1.3.2",
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.6",
-        "eslint": "^9.23.0",
-        "eslint-plugin-react": "^7.37.4",
-        "eslint-plugin-react-hooks": "^5.2.0",
-        "globals": "^16.0.0",
-        "prettier": "^3.5.3",
-        "typescript": "^5.8.3",
-        "typescript-eslint": "^8.29.0"
+        "@eslint/compat": ">=1.2.7",
+        "@eslint/js": ">=9.23.0",
+        "@rsbuild/core": ">=1.3.15",
+        "@rsbuild/plugin-react": ">=1.3.2",
+        "@types/react": ">=19.1.2",
+        "@types/react-dom": ">=19.1.6",
+        "eslint": ">=9.23.0",
+        "eslint-plugin-react": ">=7.37.4",
+        "eslint-plugin-react-hooks": ">=5.2.0",
+        "globals": ">=16.0.0",
+        "prettier": ">=3.5.3",
+        "typescript": ">=5.8.3",
+        "typescript-eslint": ">=8.29.0"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
Follow-up to #1438 