### PR TITLE
frontend: Better communicate that the preview is just a preview

### DIFF
--- a/jawanndenn/frontend/src/Poll.css
+++ b/jawanndenn/frontend/src/Poll.css
@@ -52,3 +52,18 @@
 .sumNonZero {
   font-weight: bold;
 }
+
+.poll.preview .MuiCardHeader-root {
+  padding-bottom: 0;
+  text-align: center;
+}
+
+.poll.preview .MuiCardHeader-content span {
+  font-size: 30pt;
+  font-weight: 100;
+  color: #ccc;
+}
+
+.poll.preview .MuiCardContent-root h2 {
+  margin-top: 0;
+}

--- a/jawanndenn/frontend/src/Poll.tsx
+++ b/jawanndenn/frontend/src/Poll.tsx
@@ -8,6 +8,7 @@ import TristateCheckbox from './TristateCheckbox.tsx';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
 import TextField from '@mui/material/TextField';
 
 import { useState } from 'react';
@@ -76,7 +77,8 @@ const Poll = ({
   };
 
   return (
-    <Card className="poll">
+    <Card className={`poll ${pretend ? 'preview' : ''}`}>
+      {pretend && <CardHeader title="Preview" />}
       <CardContent>
         <h2
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
Related: https://github.com/hartwork/jawanndenn/issues/26#issuecomment-2955896978

@bernhardreiter would this :arrow_down: "Preview" marker help in your view?

![preview](https://github.com/user-attachments/assets/d35f0053-5f0e-4450-b678-1a3ff91a4518)
