### PR TITLE
frontend: Stop showing the initial gray background for "no" votes (related to #1446)

### DIFF
--- a/jawanndenn/frontend/src/Poll.css
+++ b/jawanndenn/frontend/src/Poll.css
@@ -41,9 +41,6 @@
 .votedMaybe {
   background-color: #fff59d; /* yellow 200 */
 }
-.yetToVote {
-  background-color: #dfdfdf;
-}
 
 .submitVote {
   margin-left: 1em !important;

--- a/jawanndenn/frontend/src/Poll.tsx
+++ b/jawanndenn/frontend/src/Poll.tsx
@@ -42,7 +42,7 @@ const Poll = ({
   } else if (originalUsersVotes.length < config.options.length) {
     const filling = config.options
       .slice(originalUsersVotes.length)
-      .map((_) => undefined);
+      .map((_) => false);
     usersVotes = originalUsersVotes.concat(filling);
   }
   console.assert(usersVotes.length === config.options.length);
@@ -151,13 +151,7 @@ const Poll = ({
                   <td
                     key={column}
                     className={`vote ${
-                      yes
-                        ? 'votedYes'
-                        : yes === null
-                          ? 'votedMaybe'
-                          : yes === false
-                            ? 'votedNo'
-                            : 'yetToVote'
+                      yes ? 'votedYes' : yes === null ? 'votedMaybe' : 'votedNo'
                     }`}
                   >
                     <TristateCheckbox


### PR DESCRIPTION
Related to #1446

@bernhardreiter this :arrow_down: is going forward with saying goodbye to the initial gray background:

![Image](https://github.com/user-attachments/assets/244d4c9d-d38b-4290-ab6b-f84d859d8ed3)