### PR TITLE
ruff: Drop support for Python 3.9 and 3.10 (follow-up to #1699)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 indent-width = 4
 line-length = 99
-target-version = "py39"
+target-version = "py311"
 
 [lint]
 select = [


### PR DESCRIPTION
Follow-up to #1699 