### PR TITLE
dependabot.yml: Disable 3-days-default cooldown for PyPI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
       - "enhancement"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
 
   - package-ecosystem: "pre-commit"
     commit-message:


### PR DESCRIPTION
Related:
https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/